### PR TITLE
Fixed Regex for URLS

### DIFF
--- a/infoqscraper/main.py
+++ b/infoqscraper/main.py
@@ -315,7 +315,7 @@ class PresentationModule(Module):
                     raise ArgumentError("%s not found. Please install required dependencies or specify the binary location" % cmd)
 
         def __extract_id(self, name):
-            mo = re.search("^https?://www.infoq.com/presentations/([^/])$", name)
+            mo = re.search("^https?://www.infoq.com/presentations/([^/#?]+)", name)
             if mo:
                 return mo.group(1)
 


### PR DESCRIPTION
The old regex wouldn't match several characters at once, just the first one, so I added a + inside the parentheses.

I also got rid of the $, as it seemed unnecessary. Things like a trailing slash, or other miscellaneous params added to the URL could ruin that. In order to make sure we only got the id, I also added # and ?, which are two other common url patterns that we wouldn't want to capture anything after.

Other alternatives: 

If you just want to get rid of a possible trailing slash: 

```
mo = re.search("^https?://www.infoq.com/presentations/([^/]+)/?$", name) 
```

If you want to assume that the id will always be alphanumeric + hyphens,

```
mo = re.search("^https?://www.infoq.com/presentations/([0-9A-za-z-]+)", name) 
```
